### PR TITLE
stop chef from restarting zk on every run, even if no changes.

### DIFF
--- a/libraries/zookeeper_service.rb
+++ b/libraries/zookeeper_service.rb
@@ -86,7 +86,6 @@ module ZookeeperClusterCookbook
       include PoiseService::ServiceMixin
 
       def action_enable
-        new_resource.notifies(:restart, new_resource, :delayed)
         notifying_block do
           package new_resource.package_name do
             version new_resource.version unless new_resource.version.nil?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures a Zookeeper cluster.'
 long_description 'Application cookbook which installs and configures a Zookeeper cluster.'
-version '1.3.1'
+version '1.3.2'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
removing `notifies` from `action_enable` which as it stands will trigger a service restart on each run even when everything is up-to-date and no changes processed. tested that with this line removed chef runs with no changes will not trigger a restart and a restart will be triggered if any resources have changed.
