### PR TITLE
Values in README.md incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Chef environment. The default recipe in your wrapper cookbook may
 look something like the following block:
 ```ruby
 bag = data_bag_item('config', 'zookeeper')[node.chef_environment]
-node.default['zookeeper-cluster']['config']['instance_name'] = node['ipaddress']
-node.default['zookeeper-cluster']['config']['ensemble'] = bag['ensemble']
+node.default['zookeeper-cluster']['config']['instance_name'] = node['fqdn']
+node.default['zookeeper-cluster']['config']['ensemble'] = bag
 include_recipe 'zookeeper-cluster::default'
 ```
 
@@ -49,18 +49,18 @@ service on each node.
 ```json
 {
   "id": "zookeeper",
-  "development": {
+  "development": [
     "zk1.dev.inf.example.com",
     "zk2.dev.inf.example.com",
     "zk3.dev.inf.example.com"
-  },
-  "production": {
+  ],
+  "production": [
     "zk1.prod.inf.example.com",
     "zk2.prod.inf.example.com",
     "zk3.prod.inf.example.com",
     "zk4.prod.inf.example.com",
     "zk5.prod.inf.example.com",
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
The following 3 issues are addressed in this patch:
1. The JSON example of the data bag is malformed, it should be an array of FQDNs.
2. The value for `['zookeeper-cluster']['config']['instance_name']` is being set with the `ipaddress` instead of the `fqdn` of the node at run-time.
3. The value for `['zookeeper-cluster']['config']['ensemble']` should just be the variable `bag` as there is no property in the example JSON for `ensemble`.
