### PR TITLE
Update to add an instance_id attribute.

### DIFF
--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -46,7 +46,6 @@ module ZookeeperClusterCookbook
           'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
       end
 
-
       action(:create) do
         notifying_block do
           directory ::File.dirname(new_resource.path) do

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -38,12 +38,20 @@ module ZookeeperClusterCookbook
       # Outputs the +properties+ in the Java Properties file format. This is
       # what Zookeeper daemon consumes to tweak its internal configuration.
       def to_s
-        servers = ensemble.map { |n| "server.#{ensemble.index(n).next}:#{n}:#{leader_port}:#{election_port}" }
-        properties.merge(
-          'dataDir' => data_dir,
-          'leaderPort' => leader_port,
-          'clientPort' => client_port,
-          'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
+        if properties.key?(:dynamicConfigFile)
+          properties.merge(
+              'dataDir' => data_dir,
+              'leaderPort' => leader_port,
+              'clientPort' => client_port,
+              'electionPort' => election_port).map { |kv| kv.join('=') }.join("\n")
+        else
+          servers = ensemble.map { |n| "server.#{ensemble.index(n).next}:#{n}:#{leader_port}:#{election_port}" }
+          properties.merge(
+            'dataDir' => data_dir,
+            'leaderPort' => leader_port,
+            'clientPort' => client_port,
+            'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
+        end
       end
 
 

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -38,17 +38,12 @@ module ZookeeperClusterCookbook
       # Outputs the +properties+ in the Java Properties file format. This is
       # what Zookeeper daemon consumes to tweak its internal configuration.
       def to_s
-        retval = properties.merge(
-              'dataDir' => data_dir,
-              'leaderPort' => leader_port,
-              'clientPort' => client_port,
-              'electionPort' => election_port).map { |kv| kv.join('=') }
-
-        if !properties.key?(:dynamicConfigFile)
-          servers = ensemble.map { |n| "server.#{ensemble.index(n).next}:#{n}:#{leader_port}:#{election_port}" }
-          retval.concat(servers)
-        end
-        retval.join("\n")
+        servers = ensemble.map { |n| "server.#{ensemble.index(n).next}:#{n}:#{leader_port}:#{election_port}" }
+        properties.merge(
+          'dataDir' => data_dir,
+          'leaderPort' => leader_port,
+          'clientPort' => client_port,
+          'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
       end
 
 

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -26,6 +26,7 @@ module ZookeeperClusterCookbook
       attribute(:group, kind_of: String, default: 'zookeeper')
 
       attribute(:instance_name, kind_of: String, required: true)
+      attribute(:instance_id, kind_of: Integer, required: false)
       attribute(:data_dir, kind_of: String, default: '/var/lib/zookeeper')
       attribute(:client_port, kind_of: Integer, default: 2181)
       attribute(:leader_port, kind_of: Integer, default: 2888)
@@ -34,7 +35,11 @@ module ZookeeperClusterCookbook
       attribute(:properties, option_collector: true, default: {})
 
       def myid
-        ensemble.index(instance_name).next.to_s
+        if instance_id  != nil
+          instance_id.to_s
+        else
+          ensemble.index(instance_name).next.to_s
+        end
       end
 
       # Outputs the +properties+ in the Java Properties file format. This is

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -38,20 +38,17 @@ module ZookeeperClusterCookbook
       # Outputs the +properties+ in the Java Properties file format. This is
       # what Zookeeper daemon consumes to tweak its internal configuration.
       def to_s
-        if properties.key?(:dynamicConfigFile)
-          properties.merge(
+        retval = properties.merge(
               'dataDir' => data_dir,
               'leaderPort' => leader_port,
               'clientPort' => client_port,
-              'electionPort' => election_port).map { |kv| kv.join('=') }.join("\n")
-        else
+              'electionPort' => election_port).map { |kv| kv.join('=') }
+
+        if !properties.key?(:dynamicConfigFile)
           servers = ensemble.map { |n| "server.#{ensemble.index(n).next}:#{n}:#{leader_port}:#{election_port}" }
-          properties.merge(
-            'dataDir' => data_dir,
-            'leaderPort' => leader_port,
-            'clientPort' => client_port,
-            'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
+          retval.concat(servers)
         end
+        retval.join("\n")
       end
 
 

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -26,6 +26,7 @@ module ZookeeperClusterCookbook
       attribute(:group, kind_of: String, default: 'zookeeper')
 
       attribute(:instance_name, kind_of: String, required: true)
+      attribute(:instance_id, kind_of: Integer, required: false)
       attribute(:data_dir, kind_of: String, default: '/var/lib/zookeeper')
       attribute(:client_port, kind_of: Integer, default: 2181)
       attribute(:leader_port, kind_of: Integer, default: 2888)
@@ -34,7 +35,11 @@ module ZookeeperClusterCookbook
       attribute(:properties, option_collector: true, default: {})
 
       def myid
-        ensemble.index(instance_name).next.to_s
+        if instance_id != nil
+          instance_id.to_s
+        else
+          ensemble.index(instance_name).next.to_s
+        end
       end
 
       # Outputs the +properties+ in the Java Properties file format. This is

--- a/libraries/zookeeper_config.rb
+++ b/libraries/zookeeper_config.rb
@@ -26,21 +26,14 @@ module ZookeeperClusterCookbook
       attribute(:group, kind_of: String, default: 'zookeeper')
 
       attribute(:instance_name, kind_of: String, required: true)
-      attribute(:instance_id, kind_of: Integer, required: false)
+      attribute(:instance_id, kind_of: String, default: lazy { ensemble.index(instance_name).next.to_s })
+      alias_method :myid, :instance_id
       attribute(:data_dir, kind_of: String, default: '/var/lib/zookeeper')
       attribute(:client_port, kind_of: Integer, default: 2181)
       attribute(:leader_port, kind_of: Integer, default: 2888)
       attribute(:election_port, kind_of: Integer, default: 3888)
       attribute(:ensemble, kind_of: Array, default: [], required: true)
       attribute(:properties, option_collector: true, default: {})
-
-      def myid
-        if instance_id  != nil
-          instance_id.to_s
-        else
-          ensemble.index(instance_name).next.to_s
-        end
-      end
 
       # Outputs the +properties+ in the Java Properties file format. This is
       # what Zookeeper daemon consumes to tweak its internal configuration.
@@ -52,6 +45,7 @@ module ZookeeperClusterCookbook
           'clientPort' => client_port,
           'electionPort' => election_port).map { |kv| kv.join('=') }.concat(servers).join("\n")
       end
+
 
       action(:create) do
         notifying_block do
@@ -72,9 +66,22 @@ module ZookeeperClusterCookbook
             mode '0644'
           end
 
-          file new_resource.path do
+          # create zoo.properties.static file and only update 
+          # zoo.properties when static file has changed.
+          # this is needed to ensure chef won't constantly update
+          # zoo.properties and force restarts of zookeeper when
+          # it dynamically updates zoo.properties.
+          file new_resource.path+".static" do
             content new_resource.to_s
             mode '0644'
+            notifies :create, 'file[config_base]', :immediately
+          end
+
+          file 'config_base' do
+            content new_resource.to_s
+            path new_resource.path
+            mode '0644'
+            action :nothing       
           end
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures a Zookeeper cluster.'
 long_description 'Application cookbook which installs and configures a Zookeeper cluster.'
-version '1.3.5'
+version '1.3.4'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures a Zookeeper cluster.'
 long_description 'Application cookbook which installs and configures a Zookeeper cluster.'
-version '1.3.2'
+version '1.3.3'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures a Zookeeper cluster.'
 long_description 'Application cookbook which installs and configures a Zookeeper cluster.'
-version '1.3.3'
+version '1.3.4'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures a Zookeeper cluster.'
 long_description 'Application cookbook which installs and configures a Zookeeper cluster.'
-version '1.3.4'
+version '1.3.5'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
zookeeper V3.5.2-alpha dynamically generates a configuration file and updates the configuration file generated by chef to move the ensemble information to the dynamic file.   In my chef cookbook, I will generate the dynamic file  and stop this cookbook from generating a config file that zookeeper will update.  I will do this by not setting the ensemble field. That works but the problem is with my_id.